### PR TITLE
Add permissions in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ on:
 ```
 Note, however, that this runs the build multiple times for each commit.
 
+### Private repositories permissions
+
+For private repositories, read-only `content` access has to be granted as well, so the permissions would be:
+```yml
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
+```
+
 ### Additional options
 
 The erdpy version can be specified by providing:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Note, however, that this runs the build multiple times for each commit.
 
 ### Private repositories permissions
 
-For private repositories, read-only `content` access has to be granted as well, so the permissions would be:
+For private repositories, read-only `contents` access has to be granted as well, so the permissions would be:
 ```yml
 permissions:
   checks: write

--- a/README.md
+++ b/README.md
@@ -20,8 +20,12 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
+
+permissions:
+  checks: write
+  pull-requests: write
 
 jobs:
   contracts:
@@ -34,6 +38,20 @@ jobs:
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+### Main branch notes
+
+When using the action, pay attention to the branch naming under the push event and use either `main` or `master` accordingly. Using the wrong main branch name will cause the github actions build to be skipped, without displaying an error message.
+
+### Using more than one base branch
+
+As an alternative, when more than one branch is used as a base branch for pull requests, the following can be used instead:
+```yml
+on:
+  push:
+  pull_request:
+```
+Note, however, that this runs the build multiple times for each commit.
 
 ### Additional options
 


### PR DESCRIPTION
- added minimum required write permissions
- changed the default branch in the documentation to `main`, since it's more likely to be the correct one when creating new repositories
- added a warning about the main branch naming
- documented the use-case for multiple base branches
- document permissions for private repositories