### PR TITLE
Add clippy default args

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -23,6 +23,11 @@ on:
         default: ''
         required: false
         type: string
+      clippy-args:
+        description: 'cargo clippy arguments'
+        default: '--all-targets --all-features'
+        required: false
+        type: string
     secrets:
       token:
         description: 'Github token'
@@ -154,3 +159,4 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.token }}
+          args: ${{ inputs.clippy-args }}


### PR DESCRIPTION
Add a new workflow input, `clippy-args`, which controls the arguments for clippy.
The default arguments are `--all-targets --all-features`, as recommended by [the documentation on cargo clippy for CI builds](https://doc.rust-lang.org/stable/clippy/continuous_integration/github_actions.html).
